### PR TITLE
[bugfix] alert-notice/alertのフラッシュの閉じるボタンを追加

### DIFF
--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,5 +1,8 @@
 <% flash.each do |key, value| %>
   <div class="alert alert-<%= key %>">
+    <button type="button" class="close" data-dismiss="alert">
+      <span aria-hidden="true">&times;</span>
+    </button>
     <ul>
       <li>
         <%= value %>


### PR DESCRIPTION
* PR #3 でWikiのコードを写経した際に見落としていた閉じるボタンを追加。
* devise_helperで実装したalert-dangerのHTMLにならった。（xではなく`&times;`を使用、buttonタグを使用）